### PR TITLE
Add "On Layout Switch" correction mode, permissions menu, and broader layout detection

### DIFF
--- a/Sources/Core/InputSourceManager.swift
+++ b/Sources/Core/InputSourceManager.swift
@@ -44,12 +44,16 @@ public class InputSourceManager {
             guard let sourceID = stringProperty(source, kTISPropertyInputSourceID) else { continue }
             let sourceName = stringProperty(source, kTISPropertyLocalizedName)
 
-            for layout in Layout.allCases {
-                if layout.matches(sourceID: sourceID) && installedSourceIDs[layout] == nil {
-                    installedSourceIDs[layout] = sourceID
-                    NSLog("[SwitchFix] Discovered layout: %@ → %@", layout.rawValue, sourceID)
+            if let matchingLayout = Layout.allCases.first(where: { $0.matches(sourceID: sourceID) }) {
+                if installedSourceIDs[matchingLayout] == nil {
+                    installedSourceIDs[matchingLayout] = sourceID
+                    NSLog("[SwitchFix] Discovered layout: %@ → %@", matchingLayout.rawValue, sourceID)
                 }
             }
+            else {
+                NSLog("[SwitchFix] Unmatched input source: %@ (%@)", sourceID, sourceName ?? "unnamed")
+            }
+
 
             if Layout.ukrainian.matches(sourceID: sourceID) && ukrainianVariantBySourceID[sourceID] == nil {
                 let variant = detectUkrainianVariant(for: source, sourceName: sourceName)

--- a/Sources/Core/InputSourceManager.swift
+++ b/Sources/Core/InputSourceManager.swift
@@ -4,10 +4,6 @@ import Carbon
 public class InputSourceManager {
     public static let shared = InputSourceManager()
 
-    private var cachedLayout: Layout?
-    private var cachedLayoutTimeNs: UInt64 = 0
-    private static let layoutCacheTTLNs: UInt64 = 120_000_000 // 120ms
-
     /// Maps each Layout to the user's actual installed input source ID.
     /// Populated at startup by `discoverInstalledSources()`.
     private var installedSourceIDs: [Layout: String] = [:]
@@ -17,19 +13,7 @@ public class InputSourceManager {
     private static let bKeyCode: UInt16 = 11
 
     private init() {
-        // Listen for input source changes to invalidate cache
-        DistributedNotificationCenter.default().addObserver(
-            self,
-            selector: #selector(inputSourceChanged),
-            name: NSNotification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
-            object: nil
-        )
         discoverInstalledSources()
-    }
-
-    @objc private func inputSourceChanged() {
-        cachedLayout = nil
-        cachedLayoutTimeNs = 0
     }
 
     public struct InputSourceDescriptor: Equatable {
@@ -68,22 +52,8 @@ public class InputSourceManager {
 
     /// Get the current active keyboard layout (cached until input source changes).
     public func currentLayout() -> Layout {
-        let now = DispatchTime.now().uptimeNanoseconds
-        if let cachedLayout,
-           now &- cachedLayoutTimeNs < InputSourceManager.layoutCacheTTLNs {
-            return cachedLayout
-        }
-
         let layout = fetchCurrentLayout()
-        cachedLayout = layout
-        cachedLayoutTimeNs = now
         return layout
-    }
-
-    /// Force-refresh the cached layout after a programmatic switch.
-    public func invalidateCache() {
-        cachedLayout = nil
-        cachedLayoutTimeNs = 0
     }
 
     /// The raw input source ID of the current keyboard layout.
@@ -141,8 +111,6 @@ public class InputSourceManager {
                 if sourceID == targetID {
                     let status = TISSelectInputSource(source)
                     NSLog("[SwitchFix] switchTo(%@): selected %@ (status: %d)", layout.rawValue, sourceID, status)
-                    cachedLayout = layout
-                    cachedLayoutTimeNs = DispatchTime.now().uptimeNanoseconds
                     return
                 }
             }

--- a/Sources/Core/LayoutDetector.swift
+++ b/Sources/Core/LayoutDetector.swift
@@ -8,6 +8,20 @@ public struct DetectionResult {
     public let convertedWord: String
     public let originalWord: String
     public let shouldSwitchLayout: Bool
+
+    public init(
+        sourceLayout: Layout,
+        targetLayout: Layout,
+        convertedWord: String,
+        originalWord: String,
+        shouldSwitchLayout: Bool
+    ) {
+        self.sourceLayout = sourceLayout
+        self.targetLayout = targetLayout
+        self.convertedWord = convertedWord
+        self.originalWord = originalWord
+        self.shouldSwitchLayout = shouldSwitchLayout
+    }
 }
 
 /// State machine for layout detection.

--- a/Sources/Core/LayoutMapper.swift
+++ b/Sources/Core/LayoutMapper.swift
@@ -27,28 +27,29 @@ public enum Layout: String, CaseIterable, Equatable {
     public var inputSourceIDs: [String] {
         switch self {
         case .english: return [
-            "com.apple.keylayout.US",
-            "com.apple.keylayout.ABC",
-            "com.apple.keylayout.British",
-            "com.apple.keylayout.USInternational-PC",
-            "com.apple.keylayout.Colemak",
-            "com.apple.keylayout.Dvorak",
+            "keylayout.US",
+            "keylayout.USExtended",
+            "keylayout.ABC",
+            "keylayout.British",
+            "keylayout.USInternational-PC",
+            "keylayout.Colemak",
+            "keylayout.Dvorak",
         ]
         case .ukrainian: return [
-            "com.apple.keylayout.Ukrainian",
-            "com.apple.keylayout.Ukrainian-PC",
+            "keylayout.Ukrainian",
+            "keylayout.Ukrainian-PC",
         ]
         case .russian: return [
-            "com.apple.keylayout.Russian",
-            "com.apple.keylayout.RussianWin",
-            "com.apple.keylayout.Russian-Phonetic",
+            "keylayout.Russian",
+            "keylayout.RussianWin",
+            "keylayout.Russian-Phonetic",
         ]
         }
     }
 
     /// Check if a given input source ID matches this layout.
     public func matches(sourceID: String) -> Bool {
-        return inputSourceIDs.contains(sourceID)
+        return inputSourceIDs.contains(where: { sourceID.hasSuffix($0) })
     }
 }
 

--- a/Sources/Core/TextCorrector.swift
+++ b/Sources/Core/TextCorrector.swift
@@ -199,7 +199,12 @@ public class TextCorrector {
     }
 
     /// Perform correction on selected text by replacing it via clipboard paste.
-    public func performSelectionCorrection(selectedText: String, convertedText: String, targetLayout: Layout) {
+    public func performSelectionCorrection(
+        selectedText: String,
+        convertedText: String,
+        targetLayout: Layout,
+        shouldSwitchLayout: Bool = true
+    ) {
         lastOriginalText = selectedText
         lastCorrectedText = convertedText
         lastCorrectionTime = Date()
@@ -219,8 +224,9 @@ public class TextCorrector {
         // Simulate Cmd+V to replace selection
         simulatePaste()
 
-        // Switch layout to target
-        inputSourceManager.switchTo(targetLayout)
+        if shouldSwitchLayout {
+            inputSourceManager.switchTo(targetLayout)
+        }
 
         // Restore clipboard and resume monitoring after paste completes
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in

--- a/Sources/SwitchFixApp/AppDelegate.swift
+++ b/Sources/SwitchFixApp/AppDelegate.swift
@@ -136,7 +136,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self,
             selector: #selector(selectedInputSourceChanged),
             name: NSNotification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
-            object: nil
+            object: nil,
+            suspensionBehavior: .deliverImmediately
         )
         return true
     }
@@ -160,7 +161,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             NSLog("[SwitchFix] Warning: observed CapsLock conflict (input source changed immediately after revert hotkey)")
             return
         }
-        
+
         NSLog("[SwitchFix] Input source changed: %@ -> %@", previousLayout.rawValue, newLayout.rawValue)
 
         guard !isCorrectionInProgress else { return }

--- a/Sources/SwitchFixApp/AppDelegate.swift
+++ b/Sources/SwitchFixApp/AppDelegate.swift
@@ -16,6 +16,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var isCurrentAppAllowed: Bool = true
     private var capsLockConflictProbeToken: UUID?
     private var monitoringObserversRegistered: Bool = false
+    private var previousLayout: Layout = .english
+    private var isCorrectionInProgress: Bool = false
     private static let capsLockKeyCode: UInt16 = 57
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -25,6 +27,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         setupCorrectionEngine()
         prewarmDictionaries()
+
+        previousLayout = inputSourceManager.currentLayout()
 
         Permissions.ensureRequiredPermissions { [weak self] in
             guard let self else { return }
@@ -58,10 +62,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         textCorrector = TextCorrector()
         textCorrector?.onCorrectionStarted = { [weak self] in
+            self?.isCorrectionInProgress = true
             self?.keyboardMonitor?.isPaused = true
             self?.layoutDetector?.beginCorrection()
         }
         textCorrector?.onCorrectionFinished = { [weak self] in
+            self?.isCorrectionInProgress = false
             self?.keyboardMonitor?.isPaused = false
             self?.layoutDetector?.endCorrection()
         }
@@ -145,10 +151,46 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func selectedInputSourceChanged() {
-        guard capsLockConflictProbeToken != nil else { return }
-        capsLockConflictProbeToken = nil
-        SystemHotkeyConflicts.markObservedCapsLockConflict()
-        NSLog("[SwitchFix] Warning: observed CapsLock conflict (input source changed immediately after revert hotkey)")
+        let newLayout = inputSourceManager.currentLayout()
+        defer { previousLayout = newLayout }
+
+        if capsLockConflictProbeToken != nil {
+            capsLockConflictProbeToken = nil
+            SystemHotkeyConflicts.markObservedCapsLockConflict()
+            NSLog("[SwitchFix] Warning: observed CapsLock conflict (input source changed immediately after revert hotkey)")
+            return
+        }
+        
+        NSLog("[SwitchFix] Input source changed: %@ -> %@", previousLayout.rawValue, newLayout.rawValue)
+
+        guard !isCorrectionInProgress else { return }
+        guard PreferencesManager.shared.correctionMode == .layoutSwitch else { return }
+        guard PreferencesManager.shared.isEnabled else { return }
+        guard isCurrentAppAllowed else { return }
+        guard newLayout != previousLayout else { return }
+
+        triggerLayoutSwitchCorrection(from: previousLayout, to: newLayout)
+    }
+
+    /// Returns true when `text` contains at least one letter belonging to the script
+    /// of `layout` (Latin for English, Cyrillic for Ukrainian/Russian). Text that has
+    /// no letters of the expected script is considered foreign and should not be
+    /// transcribed from `layout`.
+    private func textContainsScript(of layout: Layout, text: String) -> Bool {
+        let latinLowercase: ClosedRange<UInt32> = 0x0061...0x007A
+        let latinUppercase: ClosedRange<UInt32> = 0x0041...0x005A
+        let cyrillicRange: ClosedRange<UInt32> = 0x0400...0x04FF
+
+        switch layout {
+        case .english:
+            return text.unicodeScalars.contains { scalar in
+                latinLowercase.contains(scalar.value) || latinUppercase.contains(scalar.value)
+            }
+        case .ukrainian, .russian:
+            return text.unicodeScalars.contains { scalar in
+                cyrillicRange.contains(scalar.value)
+            }
+        }
     }
 
     private func startCapsLockConflictProbe() {
@@ -215,6 +257,67 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         textCorrector?.recordUserInput(kind: .other)
         return true
     }
+    
+    private func triggerLayoutSwitchCorrection(from fromLayout: Layout, to toLayout: Layout) {
+        let fromVariant = inputSourceManager.currentUkrainianVariant() ?? inputSourceManager.preferredUkrainianVariant()
+        let toVariant = inputSourceManager.preferredUkrainianVariant()
+
+        if let selection = Permissions.getSelectedText(), !selection.isEmpty {
+            guard textContainsScript(of: fromLayout, text: selection) else {
+                NSLog("[SwitchFix] Layout-switch correction: selection not in %@ script, skipping", fromLayout.rawValue)
+                return
+            }
+            let converted = LayoutMapper.convert(
+                selection,
+                from: fromLayout,
+                to: toLayout,
+                ukrainianFromVariant: fromVariant,
+                ukrainianToVariant: toVariant
+            )
+            guard converted != selection else { return }
+            NSLog("[SwitchFix] Layout-switch correction: selection '%@' → '%@' (%@→%@)", selection, converted, fromLayout.rawValue, toLayout.rawValue)
+            layoutDetector?.discardBuffer()
+            textCorrector?.performSelectionCorrection(
+                selectedText: selection,
+                convertedText: converted,
+                targetLayout: toLayout,
+                shouldSwitchLayout: false
+            )
+            return
+        }
+
+        guard let detector = layoutDetector, !detector.currentBuffer.isEmpty else { return }
+        let originalWord = detector.currentBuffer
+        guard textContainsScript(of: fromLayout, text: originalWord) else {
+            NSLog("[SwitchFix] Layout-switch correction: buffer '%@' not in %@ script, skipping",
+                  originalWord, fromLayout.rawValue)
+            detector.discardBuffer()
+            return
+        }
+        let converted = LayoutMapper.convert(
+            originalWord,
+            from: fromLayout,
+            to: toLayout,
+            ukrainianFromVariant: fromVariant,
+            ukrainianToVariant: toVariant
+        )
+        guard converted != originalWord else { return }
+
+        NSLog("[SwitchFix] Layout-switch correction: buffer '%@' → '%@' (%@→%@)",
+              originalWord, converted, fromLayout.rawValue, toLayout.rawValue)
+
+        let result = DetectionResult(
+            sourceLayout: fromLayout,
+            targetLayout: toLayout,
+            convertedWord: converted,
+            originalWord: originalWord,
+            shouldSwitchLayout: false
+        )
+        detector.discardBuffer()
+        textCorrector?.performCorrection(result: result, boundaryCharacter: nil)
+        textCorrector?.recordUserInput(kind: .other)
+    }
+    
     @objc private func preferencesDidUpdate() {
         guard let monitor = keyboardMonitor else { return }
         monitor.hotkeyKeyCode = PreferencesManager.shared.hotkeyKeyCode
@@ -249,7 +352,8 @@ extension AppDelegate: KeyboardMonitorDelegate {
         guard isCurrentAppAllowed else { return }
         textCorrector?.noteUserEdit()
 
-        if PreferencesManager.shared.correctionMode == .automatic {
+        switch PreferencesManager.shared.correctionMode {
+        case .automatic:
             // Automatic mode: flush triggers detection + correction
             // Pass boundary character (space, punctuation, newline, etc.) so correction can retype it
             let layout = inputSourceManager.currentLayout()
@@ -257,8 +361,9 @@ extension AppDelegate: KeyboardMonitorDelegate {
             refreshLayoutVariants(for: layout)
             let boundary = character.isEmpty ? nil : character
             layoutDetector?.flushBuffer(boundaryCharacter: boundary)
-        } else {
-            // Hotkey mode: just discard the buffer (word boundary passed)
+        case .hotkey, .layoutSwitch:
+            // Discard the buffer on word boundary — correction is triggered elsewhere
+            // (via hotkey, or via system keyboard-layout change)
             layoutDetector?.discardBuffer()
         }
         textCorrector?.recordUserInput(kind: .boundary)

--- a/Sources/UI/PreferencesManager.swift
+++ b/Sources/UI/PreferencesManager.swift
@@ -5,6 +5,7 @@ import ServiceManagement
 public enum CorrectionMode: String {
     case automatic
     case hotkey
+    case layoutSwitch
 }
 
 public class PreferencesManager {

--- a/Sources/UI/SettingsView.swift
+++ b/Sources/UI/SettingsView.swift
@@ -166,7 +166,18 @@ struct HotkeyRecorder: View {
 
 struct SettingsView: View {
     @StateObject private var model = SettingsViewModel()
-    
+
+    private var correctionModeDescription: String {
+        switch model.correctionMode {
+        case .automatic:
+            return "Auto-corrects on word boundaries (space, enter)."
+        case .hotkey:
+            return "Corrects only when triggered via hotkey."
+        case .layoutSwitch:
+            return "Corrects the current word (or selection) when you switch the system keyboard layout."
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             
@@ -185,12 +196,11 @@ struct SettingsView: View {
                 Picker("", selection: $model.correctionMode) {
                     Text("Automatic (Space / Enter)").tag(CorrectionMode.automatic)
                     Text("Hotkey Only").tag(CorrectionMode.hotkey)
+                    Text("On Layout Switch").tag(CorrectionMode.layoutSwitch)
                 }
                 .pickerStyle(RadioGroupPickerStyle())
                 
-                Text(model.correctionMode == .automatic
-                     ? "Auto-corrects on word boundaries (space, enter)."
-                     : "Corrects only when triggered via hotkey.")
+                Text(correctionModeDescription)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }

--- a/Sources/UI/StatusBarController.swift
+++ b/Sources/UI/StatusBarController.swift
@@ -77,6 +77,11 @@ public class StatusBarController: NSObject, NSMenuDelegate {
         hotkeyItem.state = prefs.correctionMode == .hotkey ? .on : .off
         modeMenu.addItem(hotkeyItem)
 
+        let layoutSwitchItem = NSMenuItem(title: "On Layout Switch", action: #selector(setLayoutSwitchMode), keyEquivalent: "")
+        layoutSwitchItem.target = self
+        layoutSwitchItem.state = prefs.correctionMode == .layoutSwitch ? .on : .off
+        modeMenu.addItem(layoutSwitchItem)
+
         let modeMenuItem = NSMenuItem(title: "Correction Mode", action: nil, keyEquivalent: "")
         modeMenuItem.submenu = modeMenu
         menu.addItem(modeMenuItem)
@@ -148,6 +153,11 @@ public class StatusBarController: NSObject, NSMenuDelegate {
         refreshModeMenu()
     }
 
+    @objc private func setLayoutSwitchMode() {
+        PreferencesManager.shared.correctionMode = .layoutSwitch
+        refreshModeMenu()
+    }
+
     @objc private func toggleLaunchAtLogin(_ sender: NSMenuItem) {
         let prefs = PreferencesManager.shared
         prefs.launchAtLogin = !prefs.launchAtLogin
@@ -168,6 +178,8 @@ public class StatusBarController: NSObject, NSMenuDelegate {
                 item.state = mode == .automatic ? .on : .off
             } else if item.title == "Hotkey Only" {
                 item.state = mode == .hotkey ? .on : .off
+            } else if item.title == "On Layout Switch" {
+                item.state = mode == .layoutSwitch ? .on : .off
             }
         }
     }

--- a/Sources/UI/StatusBarController.swift
+++ b/Sources/UI/StatusBarController.swift
@@ -11,6 +11,8 @@ public class StatusBarController: NSObject, NSMenuDelegate {
     private var installedLayoutsMenuItem: NSMenuItem!
     private var conflictMenuItem: NSMenuItem?
     private var conflictSeparatorItem: NSMenuItem?
+    private var permissionMenuItems: [NSMenuItem] = []
+    private var permissionSeparatorItem: NSMenuItem?
 
     public override init() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -122,6 +124,7 @@ public class StatusBarController: NSObject, NSMenuDelegate {
         menu.addItem(quitItem)
 
         refreshSystemHotkeyConflictIndicator()
+        refreshPermissionIndicators()
     }
 
     @objc private func openSettings() {
@@ -241,6 +244,77 @@ public class StatusBarController: NSObject, NSMenuDelegate {
         installedLayoutsMenuItem.submenu = buildInstalledLayoutsMenu()
     }
 
+    private func refreshPermissionIndicators() {
+        permissionMenuItems.forEach { menu.removeItem($0) }
+        permissionMenuItems.removeAll()
+        if let separator = permissionSeparatorItem {
+            menu.removeItem(separator)
+            permissionSeparatorItem = nil
+        }
+
+        var itemsToInsert: [NSMenuItem] = []
+
+        if !Permissions.isAccessibilityGranted() {
+            let item = NSMenuItem(
+                title: "Grant Accessibility Permission…",
+                action: #selector(openAccessibilityPermissionSettings),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.toolTip = "SwitchFix needs Accessibility access to monitor keyboard input and replace mistyped words."
+            itemsToInsert.append(item)
+        }
+
+        if !Permissions.isInputMonitoringGranted() {
+            let item = NSMenuItem(
+                title: "Grant Input Monitoring Permission…",
+                action: #selector(openInputMonitoringPermissionSettings),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.toolTip = "SwitchFix needs Input Monitoring access to observe keystrokes."
+            itemsToInsert.append(item)
+        }
+
+        guard !itemsToInsert.isEmpty else {
+            updateMenuBarTooltipForPermissions()
+            return
+        }
+
+        for (index, item) in itemsToInsert.enumerated() {
+            menu.insertItem(item, at: index)
+        }
+        let separator = NSMenuItem.separator()
+        menu.insertItem(separator, at: itemsToInsert.count)
+
+        permissionMenuItems = itemsToInsert
+        permissionSeparatorItem = separator
+
+        updateMenuBarTooltipForPermissions()
+    }
+
+    private func updateMenuBarTooltipForPermissions() {
+        guard permissionMenuItems.isEmpty else {
+            statusItem.button?.toolTip = "SwitchFix (missing permissions)"
+            return
+        }
+
+        let hasConflict = SystemHotkeyConflicts.hasCapsLockConflict(
+            revertHotkeyKeyCode: PreferencesManager.shared.revertHotkeyKeyCode
+        )
+        statusItem.button?.toolTip = hasConflict
+            ? "SwitchFix (CapsLock conflict detected)"
+            : "SwitchFix"
+    }
+
+    @objc private func openAccessibilityPermissionSettings() {
+        Permissions.openAccessibilitySettings()
+    }
+
+    @objc private func openInputMonitoringPermissionSettings() {
+        Permissions.openInputMonitoringSettings()
+    }
+
     private func refreshSystemHotkeyConflictIndicator() {
         let hasConflict = SystemHotkeyConflicts.hasCapsLockConflict(
             revertHotkeyKeyCode: PreferencesManager.shared.revertHotkeyKeyCode
@@ -279,6 +353,7 @@ public class StatusBarController: NSObject, NSMenuDelegate {
     public func menuWillOpen(_ menu: NSMenu) {
         if menu === self.menu {
             refreshSystemHotkeyConflictIndicator()
+            refreshPermissionIndicators()
             refreshAppFilterMenuItem()
             refreshInstalledLayoutsMenu()
             refreshModeMenu()


### PR DESCRIPTION
**1. New correction mode: "On Layout Switch"**
Introduces CorrectionMode.layoutSwitch as a third option next to automatic and hotkey. When enabled, SwitchFix observes NSTextInputContext.keyboardSelectionDidChangeNotification and, on a real layout change, transcribes either:

the currently selected text (via Permissions.getSelectedText()), or
the current in-progress word buffer from LayoutDetector,
from the previous layout into the new one — without triggering an additional layout switch (new shouldSwitchLayout flag on TextCorrector.performSelectionCorrection and DetectionResult).

A new helper AppDelegate.textContainsScript(of:text:) skips conversion when the selected text doesn't actually contain letters of the source layout's script (Latin for English, Cyrillic for Ukrainian/Russian), preventing spurious transcriptions of already-foreign text.

UI:
SettingsView exposes the new mode with a descriptive caption.
StatusBarController adds an "On Layout Switch" item to the Correction Mode submenu.

**2. Permissions visible in the menu bar**
StatusBarController now surfaces missing Accessibility and Input Monitoring permissions directly in the status bar menu, with click-through items that open the relevant System Settings panes (openAccessibilitySettings / openInputMonitoringSettings). The menu bar tooltip reflects a "missing permissions" state, and the indicators refresh every time the menu opens — so users can grant permissions after first launch without restarting the app.

**3. Wider input-layout coverage**
LayoutMapper matches input source IDs by suffix (e.g. keylayout.US) instead of exact full bundle IDs, and adds USExtended to the English set. This accommodates third-party and non-com.apple.keylayout.* sources. InputSourceManager now logs any unmatched input sources to aid diagnostics and avoids repeated matching work per source.

**Files changed**
Sources/Core/InputSourceManager.swift — single-pass matching + unmatched-source logging
Sources/Core/LayoutMapper.swift — suffix-based matches(sourceID:), added USExtended
Sources/Core/LayoutDetector.swift — public memberwise initializer for DetectionResult
Sources/Core/TextCorrector.swift — optional shouldSwitchLayout parameter
Sources/SwitchFixApp/AppDelegate.swift — layout-change observer, triggerLayoutSwitchCorrection, textContainsScript helper, correction-in-progress guard
Sources/UI/PreferencesManager.swift — new CorrectionMode.layoutSwitch case
Sources/UI/SettingsView.swift — picker option + per-mode description
Sources/UI/StatusBarController.swift — permission menu items, tooltip, new mode entry